### PR TITLE
feat: Allow setting of boundaries in multipart

### DIFF
--- a/lib/src/boundary.dart
+++ b/lib/src/boundary.dart
@@ -22,22 +22,40 @@ const List<int> _boundaryCharacters = <int>[
   122
 ];
 
-/// The total length of the multipart boundaries used when building the
+/// The maximum length of the multipart boundaries used when building the
 /// request body.
 ///
 /// According to http://tools.ietf.org/html/rfc1341.html, this can't be longer
 /// than 70.
-const int _boundaryLength = 70;
+const int _maxBoundaryLength = 70;
 
 final Random _random = Random();
 
-/// Returns a randomly-generated multipart boundary string
+/// Returns a randomly-generated multipart boundary string.
 String boundaryString() {
   const prefix = 'dart-http-boundary-';
   final list = List<int>.generate(
-    _boundaryLength - prefix.length,
+    _maxBoundaryLength - prefix.length,
     (index) => _boundaryCharacters[_random.nextInt(_boundaryCharacters.length)],
     growable: false,
   );
   return '$prefix${String.fromCharCodes(list)}';
+}
+
+/// Determines if the [boundary] is a valid multipart boundary string.
+bool validBoundaryString(String boundary) {
+  // Boundary string must be between 1 - 70 characters long
+  final count = boundary.length;
+  if ((count < 1) || (count > _maxBoundaryLength)) {
+    return false;
+  }
+
+  // All boundary characters must be valid
+  for (var i = 0; i < count; ++i) {
+    if (!_boundaryCharacters.contains(boundary.codeUnitAt(i))) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/lib/src/multipart_body.dart
+++ b/lib/src/multipart_body.dart
@@ -10,6 +10,7 @@ import 'dart:convert';
 import 'package:typed_data/typed_buffers.dart';
 
 import 'body.dart';
+import 'boundary.dart';
 import 'multipart_file.dart';
 import 'utils.dart';
 
@@ -26,6 +27,11 @@ class MultipartBody implements Body {
     Iterable<MultipartFile> files,
     String boundary,
   ) {
+    if (!validBoundaryString(boundary)) {
+        throw ArgumentError.value(
+            boundary, 'boundary', 'boundary string is invalid');
+    }
+
     final controller = StreamController<List<int>>(sync: true);
     final buffer = Uint8Buffer();
 

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -155,12 +155,12 @@ class Request extends Message {
     Map<String, Object> context,
     Map<String, String> fields,
     Iterable<MultipartFile> files,
+    String boundary,
   }) {
     fields ??= const {};
     files ??= const [];
     headers ??= {};
-
-    final boundary = boundaryString();
+    boundary ??= boundaryString();
 
     return Request._(
       method ?? 'POST',

--- a/test/boundary_test.dart
+++ b/test/boundary_test.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:http_next/http.dart';
+import 'package:http_next/src/boundary.dart';
+
+final _validBoundaries = [
+  // 1 character is fine
+  'd',
+  'dart-http-boundary',
+  // Generated boundary
+  boundaryString(),
+];
+
+final _invalidBoundaries = [
+  // Boundary must be at least 1 character
+  '',
+  // Boundary must be less than 70 characters
+  String.fromCharCodes(List.generate(71, (index) => 92)),
+  // Invalid character !
+  'dart-http-boundary-!',
+  // Invalid character %
+  'dart-http-boundary-%',
+];
+
+void main() {
+  test('create boundary', () {
+    final boundary = boundaryString();
+    expect(boundary, startsWith('dart-http-boundary-'));
+    expect(boundary, hasLength(70));
+    expect(validBoundaryString(boundary), isTrue);
+  });
+
+  test('valid boundary', () {
+    for (final boundary in _validBoundaries) {
+      expect(validBoundaryString(boundary), isTrue);
+    }
+  });
+
+  test('invalid boundary', () {
+    for (final boundary in _invalidBoundaries) {
+      expect(validBoundaryString(boundary), isFalse);
+    }
+  });
+
+  test('invalid boundary in multipart', () {
+    final url = Uri.parse('http://localhost/');
+    for (final boundary in _invalidBoundaries) {
+      expect(
+        () => Request.multipart(url, boundary: boundary),
+        throwsArgumentError,
+      );
+    }
+  });
+}


### PR DESCRIPTION
Add a parameter for `boundary` within the `Request.multiPart` constructor. If it is not set then a boundary is generated. Also add a check to validate the boundary string.