### PR TITLE
feat: Support repeating field names in multipart request

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -139,7 +139,11 @@ class Request extends Message {
   /// [Request] to [url], which can be a [Uri] or a [String].
   ///
   /// The content of the body is specified through the values of [fields] and
-  /// [files].
+  /// [files]. The name for a field can be reused so the [fields] type is
+  /// treated as `Map<String, String | List<String>>`.
+  ///
+  /// The [boundary] is used to separate key value pairs within the body. If
+  /// [boundary] is `null` a random boundary string will be generated.
   ///
   /// If [method] is not specified it defaults to POST.
   ///
@@ -153,7 +157,7 @@ class Request extends Message {
     String method,
     Map<String, String> headers,
     Map<String, Object> context,
-    Map<String, String> fields,
+    Map<String, Object> fields,
     Iterable<MultipartFile> files,
     String boundary,
   }) {

--- a/test/multipart_test.dart
+++ b/test/multipart_test.dart
@@ -21,6 +21,21 @@ void main() {
         '''));
   });
 
+  test('errors', () {
+    expect(
+        () => http.Request.multipart(
+              dummyUrl,
+              fields: <String, Object>{'foo': 2},
+            ),
+        throwsArgumentError);
+    expect(
+        () => http.Request.multipart(
+              dummyUrl,
+              fields: <String, Object>{'foo': null},
+            ),
+        throwsArgumentError);
+  });
+
   test('with fields and files', () {
     final fields = <String, String>{
       'field1': 'value1',
@@ -108,6 +123,25 @@ void main() {
         content-transfer-encoding: binary
 
         vⱥlūe
+        --{{boundary}}--
+        '''));
+  });
+
+  test('with multiple fields of the same name', () {
+    final fields = {
+      'field': ['value1', 'value2']
+    };
+    final request = http.Request.multipart(dummyUrl, fields: fields);
+
+    expect(request, multipartBodyMatches('''
+        --{{boundary}}
+        content-disposition: form-data; name="field"
+
+        value1
+        --{{boundary}}
+        content-disposition: form-data; name="field"
+
+        value2
         --{{boundary}}--
         '''));
   });


### PR DESCRIPTION
In a multi-part request the field names can be repeated. Add support for this by allowing the value of the fields map to be a `String` or `List<String>`.