### PR TITLE
feat: Add extension for controlling IOClient

### DIFF
--- a/lib/http.dart
+++ b/lib/http.dart
@@ -16,7 +16,6 @@ export 'src/base_client.dart';
 export 'src/client.dart';
 export 'src/exception.dart';
 export 'src/handler.dart';
-export 'src/io_client.dart';
 export 'src/middleware.dart';
 export 'src/multipart_file.dart';
 export 'src/pipeline.dart';

--- a/lib/io_client.dart
+++ b/lib/io_client.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+export 'src/io_client.dart';
+export 'src/io_client_context.dart';

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -12,9 +12,9 @@ import 'package:pedantic/pedantic.dart';
 import 'base_client.dart';
 import 'client.dart';
 import 'exception.dart';
+import 'io_client_context.dart';
 import 'request.dart';
 import 'response.dart';
-import 'utils.dart';
 
 /// Returns an [IOClient].
 Client platformClient() => IOClient();
@@ -24,22 +24,7 @@ Client platformClient() => IOClient();
 /// This is the default client when running on the command line.
 ///
 /// You can control the underlying `dart:io` [HttpRequest] by adding values to
-/// [Request.context]:
-///
-/// * `"http.io.follow_redirects"` is a boolean. If it's `true` (the default)
-///   then the request will automatically follow HTTP redirects. If it's
-///   `false`, the client will need to handle redirects manually. See also
-///   [HttpClientRequest.followRedirects].
-///
-/// * `"http.io.max_redirects"` is an integer that specifies the maximum number
-///   of redirects that will be followed if `follow_redirects` is `true`. If the
-///   site redirects more than this, [send] will throw a [ClientException]. It
-///   defaults to `5`. See also [HttpClientRequest.maxRedirects].
-///
-/// * `"http.io.persistent_connection"` is a boolean. If it's `true` (the
-///   default) the client will request that the TCP connection be kept alive
-///   after the request completes. See also
-///   [HttpClientRequest.persistentConnection].
+/// [Request.context] through [IOClientContext].
 class IOClient extends BaseClient {
   /// Creates a new HTTP client.
   IOClient([HttpClient inner]) : _inner = inner ?? HttpClient();
@@ -51,24 +36,12 @@ class IOClient extends BaseClient {
   FutureOr<Response> send(Request request) async {
     try {
       final ioRequest = await _inner.openUrl(request.method, request.url);
-      final context = request.context;
 
       ioRequest
-        ..followRedirects = getContext<bool>(
-          context,
-          'http.io.follow_redirects',
-          true,
-        )
-        ..maxRedirects = getContext<int>(
-          context,
-          'http.io.max_redirects',
-          5,
-        )
-        ..persistentConnection = getContext<bool>(
-          context,
-          'http.io.persistent_connection',
-          true,
-        );
+        ..followRedirects = request.followRedirects
+        ..maxRedirects = request.maxRedirects
+        ..persistentConnection = request.persistentConnection;
+
       request.headers.forEach(ioRequest.headers.set);
 
       unawaited(request.read().pipe(ioRequest));

--- a/lib/src/io_client_context.dart
+++ b/lib/src/io_client_context.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'request.dart';
+import 'utils.dart';
+
+/// Allows the [Request] to control the underlying [IOClient].
+extension IOClientContext on Request {
+  static const _followRedirectsKey = 'http.io.follow_redirects';
+  static const _maxRedirectsKey = 'http.io.max_redirects';
+  static const _persistentConnectionKey = 'http.io.persistent_connection';
+
+  /// Whether the `dart:io` [HttpRequest] should follow redirects.
+  ///
+  /// When its `true` (the default) then the request will automatically follow
+  /// HTTP redirects. If it's `false`, the client will need to handle redirects
+  /// manually. See also [HttpClientRequest.followRedirects].
+  bool get followRedirects =>
+      getContext<bool>(context, _followRedirectsKey, true);
+
+  /// The maximum number of redirects that will be followed if [followRedirects]
+  /// is `true`.
+  ///
+  /// If the site redirects more than this, [send] will throw a
+  /// [ClientException]. It defaults to `5`. See also
+  /// [HttpClientRequest.maxRedirects].
+  int get maxRedirects => getContext<int>(context, _maxRedirectsKey, 5);
+
+  /// Whether the client will request that the TCP connection be kept alive
+  /// after the request completes.
+  ///
+  /// The default value is `true`. See also
+  /// [HttpClientRequest.persistentConnection].
+  bool get persistentConnection =>
+      getContext<bool>(context, _persistentConnectionKey, true);
+
+  /// Modifies the [Request.context] to set [IOClient] specific values.
+  Request changeIOClientContext({
+    bool followRedirects,
+    int maxRedirects,
+    bool persistentConnection,
+  }) {
+    final context = <String, dynamic>{};
+
+    if (followRedirects != null) {
+      context[_followRedirectsKey] = followRedirects;
+    }
+    if (maxRedirects != null) {
+      context[_maxRedirectsKey] = maxRedirects;
+    }
+    if (persistentConnection != null) {
+      context[_persistentConnectionKey] = persistentConnection;
+    }
+    return change(context: context);
+  }
+}

--- a/test/io_client_context_test.dart
+++ b/test/io_client_context_test.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:http_next/http.dart';
+import 'package:http_next/io_client.dart';
+
+const String _followRedirects = 'http.io.follow_redirects';
+const String _maxRedirects = 'http.io.max_redirects';
+const String _persistentConnection = 'http.io.persistent_connection';
+
+void main() {
+  test('defaults', () {
+    final request = Request.get('http://localhost');
+    expect(request.followRedirects, isTrue);
+    expect(request.maxRedirects, equals(5));
+    expect(request.persistentConnection, isTrue);
+  });
+  test('from context', () {
+    final context = <String, Object>{
+      _followRedirects: false,
+      _maxRedirects: 10,
+      _persistentConnection: false,
+    };
+    final request = Request.get('http://localhost', context: context);
+    expect(request.followRedirects, isFalse);
+    expect(request.maxRedirects, equals(10));
+    expect(request.persistentConnection, isFalse);
+  });
+  test('change context', () {
+    final initialRequest = Request.get('http://localhost');
+    var request = initialRequest.changeIOClientContext(
+      followRedirects: false,
+      maxRedirects: 10,
+      persistentConnection: false,
+    );
+    expect(request.followRedirects, isFalse);
+    expect(request.maxRedirects, equals(10));
+    expect(request.persistentConnection, isFalse);
+
+    request = initialRequest.changeIOClientContext(
+      followRedirects: true,
+    );
+    expect(request.followRedirects, isTrue);
+    expect(request.context.containsKey(_followRedirects), isTrue);
+    expect(request.context.containsKey(_maxRedirects), isFalse);
+    expect(request.context.containsKey(_persistentConnection), isFalse);
+
+    request = initialRequest.changeIOClientContext(
+      maxRedirects: 10,
+    );
+    expect(request.maxRedirects, equals(10));
+    expect(request.context.containsKey(_followRedirects), isFalse);
+    expect(request.context.containsKey(_maxRedirects), isTrue);
+    expect(request.context.containsKey(_persistentConnection), isFalse);
+
+    request = initialRequest.changeIOClientContext(
+      persistentConnection: true,
+    );
+    expect(request.persistentConnection, isTrue);
+    expect(request.context.containsKey(_followRedirects), isFalse);
+    expect(request.context.containsKey(_maxRedirects), isFalse);
+    expect(request.context.containsKey(_persistentConnection), isTrue);
+  });
+}


### PR DESCRIPTION
Use extension methods to make it simpler to control IOClient values through the message's context.