### PR TITLE
feat: Add extension for controlling BrowserClient

### DIFF
--- a/lib/browser_client.dart
+++ b/lib/browser_client.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+export 'src/browser_client.dart';
+export 'src/browser_client_context.dart';

--- a/lib/src/browser_client_context.dart
+++ b/lib/src/browser_client_context.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'request.dart';
+import 'utils.dart';
+
+/// Allows the [Request] to control the underlying [BrowserClient].
+extension BrowserClientContext on Request {
+  static const _withCredentialsKey = 'http.io.follow_redirects';
+
+  /// Whether cross-site requests will include credentials such as cookies or
+  /// or authorization headers.
+  ///
+  /// The default value is `false`. See also [HttpRequest.withCredentials].
+  bool get withCredentials =>
+      getContext<bool>(context, _withCredentialsKey, false);
+
+  /// Modifies the [Request.context] to set [BrowserClient] specific values.
+  Request changeBrowserClientContext({
+    bool withCredentials,
+  }) {
+    final context = <String, dynamic>{};
+
+    if (withCredentials != null) {
+      context[_withCredentialsKey] = withCredentials;
+    }
+
+    return change(context: context);
+  }
+}

--- a/test/browser_client_context_test.dart
+++ b/test/browser_client_context_test.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:http_next/http.dart';
+import 'package:http_next/src/browser_client_context.dart';
+
+const String _withCredentials = 'http.io.follow_redirects';
+
+void main() {
+  test('defaults', () {
+    final request = Request.get('http://localhost');
+    expect(request.withCredentials, isFalse);
+  });
+  test('from context', () {
+    final context = <String, Object>{
+      _withCredentials: true,
+    };
+    final request = Request.get('http://localhost', context: context);
+    expect(request.withCredentials, isTrue);
+  });
+  test('change context', () {
+    final request = Request.get('http://localhost').changeBrowserClientContext(
+      withCredentials: false,
+    );
+    expect(request.withCredentials, isFalse);
+    expect(request.context.containsKey(_withCredentials), isTrue);
+  });
+}


### PR DESCRIPTION
Use extension methods to make it simpler to control BrowserClient values through the message's context.