### PR TITLE
refactor: Remove all implicit dynamics

### DIFF
--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -18,7 +18,7 @@ class Body {
   /// [body] may be either a [Body], a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null`. If it's a [String], [encoding] will be
   /// used to convert it to a [Stream<List<int>>].
-  factory Body(body, [Encoding encoding]) {
+  factory Body(Object body, [Encoding encoding]) {
     if (body is Body) {
       return body;
     }

--- a/lib/src/browser_client_context.dart
+++ b/lib/src/browser_client_context.dart
@@ -21,7 +21,7 @@ extension BrowserClientContext on Request {
   Request changeBrowserClientContext({
     bool withCredentials,
   }) {
-    final context = <String, dynamic>{};
+    final context = <String, Object>{};
 
     if (withCredentials != null) {
       context[_withCredentialsKey] = withCredentials;

--- a/lib/src/io_client_context.dart
+++ b/lib/src/io_client_context.dart
@@ -42,7 +42,7 @@ extension IOClientContext on Request {
     int maxRedirects,
     bool persistentConnection,
   }) {
-    final context = <String, dynamic>{};
+    final context = <String, Object>{};
 
     if (followRedirects != null) {
       context[_followRedirectsKey] = followRedirects;

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -40,7 +40,7 @@ abstract class Message {
   /// in [headers] will be set appropriately. If there is no existing
   /// Content-Type header, it will be set to "application/octet-stream".
   Message(
-    body, {
+    Object body, {
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -29,8 +29,8 @@ class Request extends Message {
   /// and handlers.
   Request(
     String method,
-    url, {
-    body,
+    Object url, {
+    Object body,
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,
@@ -43,8 +43,11 @@ class Request extends Message {
   ///
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
-  Request.head(url, {Map<String, String> headers, Map<String, Object> context})
-      : this('HEAD', url, headers: headers, context: context);
+  Request.head(
+    Object url, {
+    Map<String, String> headers,
+    Map<String, Object> context,
+  }) : this('HEAD', url, headers: headers, context: context);
 
   /// Creates a new GET [Request] to [url], which can be a [Uri] or a [String].
   ///
@@ -53,8 +56,11 @@ class Request extends Message {
   ///
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
-  Request.get(url, {Map<String, String> headers, Map<String, Object> context})
-      : this('GET', url, headers: headers, context: context);
+  Request.get(
+    Object url, {
+    Map<String, String> headers,
+    Map<String, Object> context,
+  }) : this('GET', url, headers: headers, context: context);
 
   /// Creates a new POST [Request] to [url], which can be a [Uri] or a [String].
   ///
@@ -69,8 +75,8 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   Request.post(
-    url,
-    body, {
+    Object url,
+    Object body, {
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,
@@ -90,8 +96,8 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   Request.put(
-    url,
-    body, {
+    Object url,
+    Object body, {
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,
@@ -112,8 +118,8 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   Request.patch(
-    url,
-    body, {
+    Object url,
+    Object body, {
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,
@@ -129,7 +135,7 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   Request.delete(
-    url, {
+    Object url, {
     Map<String, String> headers,
     Map<String, Object> context,
   }) : this('DELETE', url, headers: headers, context: context);
@@ -153,7 +159,7 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   factory Request.multipart(
-    url, {
+    Object url, {
     String method,
     Map<String, String> headers,
     Map<String, Object> context,
@@ -194,7 +200,7 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   factory Request.urlEncoded(
-    url,
+    Object url,
     Map<String, String> body, {
     String method,
     Encoding encoding,
@@ -222,7 +228,7 @@ class Request extends Message {
   Request._(
     this.method,
     this.url,
-    body,
+    Object body,
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -27,10 +27,10 @@ class Response extends Message {
   /// Extra [context] can be used to pass information between outer middleware
   /// and handlers.
   Response(
-    finalUrl,
+    Object finalUrl,
     int statusCode, {
     String reasonPhrase,
-    body,
+    Object body,
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,
@@ -48,7 +48,7 @@ class Response extends Message {
     this.finalUrl,
     this.statusCode,
     this.reasonPhrase,
-    body,
+    Object body,
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,

--- a/test/hybrid/server.dart
+++ b/test/hybrid/server.dart
@@ -71,7 +71,7 @@ Future<void> hybridMain(StreamChannel channel) async {
       return shelf.Response.ok(Stream.fromIterable([ascii.encode('body')]));
     }
 
-    final content = <String, dynamic>{
+    final content = <String, Object>{
       'method': request.method,
       'path': request.url.path,
       'headers': <String, String>{}

--- a/test/message_change_test.dart
+++ b/test/message_change_test.dart
@@ -29,11 +29,11 @@ void main() {
 /// Shared test method used by [Request] and [Response] tests to validate
 /// the behavior of `change` with different `headers` and `context` values.
 void _testChange(
-  Message Function(
-          // ignore: avoid_annotating_with_dynamic
-          {dynamic body,
-          Map<String, String> headers,
-          Map<String, Object> context})
+  Message Function({
+    Object body,
+    Map<String, String> headers,
+    Map<String, Object> context,
+  })
       factory,
 ) {
   group('body', () {

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -27,9 +27,12 @@ final _helloBytes = ascii.encode('hello,');
 final _worldBytes = ascii.encode(' world');
 
 class _TestMessage extends Message {
-  _TestMessage(Map<String, String> headers, Map<String, Object> context, body,
-      Encoding encoding)
-      : super(body, headers: headers, context: context, encoding: encoding);
+  _TestMessage(
+    Map<String, String> headers,
+    Map<String, Object> context,
+    Object body,
+    Encoding encoding,
+  ) : super(body, headers: headers, context: context, encoding: encoding);
 
   @override
   Message change(
@@ -38,11 +41,12 @@ class _TestMessage extends Message {
   }
 }
 
-Message _createMessage(
-        {Map<String, String> headers,
-        Map<String, Object> context,
-        body,
-        Encoding encoding}) =>
+Message _createMessage({
+  Map<String, String> headers,
+  Map<String, Object> context,
+  Object body,
+  Encoding encoding,
+}) =>
     _TestMessage(headers, context, body, encoding);
 
 void main() {

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -134,10 +134,12 @@ class _MultipartBodyMatches extends Matcher {
 /// A matcher that matches a [http.ClientException] with the given [message].
 ///
 /// [message] can be a String or a [Matcher].
-Matcher isClientException([Object message]) => predicate((error) {
+Matcher isClientException([Object message]) => predicate<Exception>((error) {
       expect(error, const TypeMatcher<http.ClientException>());
       if (message != null) {
-        expect(error.message, message);
+        // ignore: avoid_as
+        final except = error as http.ClientException;
+        expect(except.message, message);
       }
       return true;
     });


### PR DESCRIPTION
Replace any `dynamic` declarations with `Object` in anticipation of sound null safety.