### PR TITLE
refactor: Move cache information to an extension

### DIFF
--- a/lib/http.dart
+++ b/lib/http.dart
@@ -6,6 +6,7 @@
 
 /// A composable, [Future]-based library for making HTTP requests.
 
+export 'src/cache_response.dart';
 export 'src/client.dart';
 export 'src/client_methods.dart';
 export 'src/client_reader.dart';

--- a/lib/src/cache_response.dart
+++ b/lib/src/cache_response.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'package:http_parser/http_parser.dart';
+
+import 'response.dart';
+
+/// HTTP Cache information for a [Response].
+///
+/// A server provides caching information on requested resources through a
+/// [Response]'s headers. A [CacheResponse] provides convenience methods to
+/// access cache information through the headers.
+extension CacheResponse on Response {
+  /// The date and time after which the response's data should be considered
+  /// stale.
+  ///
+  /// This is parsed from the Expires header in [headers]. If [headers] doesn't
+  /// have an Expires header, this will be `null`.
+  ///
+  /// This value is not cached internally so subsequent calls will reparse the
+  /// HTTP date header.
+  DateTime get expires => _parseHeaderHttpDate('expires');
+
+  /// The date and time the source of the response's data was last modified.
+  ///
+  /// This is parsed from the Last-Modified header in [headers]. If [headers]
+  /// doesn't have a Last-Modified header, this will be `null`.
+  ///
+  /// This value is not cached internally so subsequent calls will reparse the
+  /// HTTP date header.
+  DateTime get lastModified => _parseHeaderHttpDate('last-modified');
+
+  DateTime _parseHeaderHttpDate(String key) {
+    final value = headers[key];
+
+    return value != null ? parseHttpDate(value) : null;
+  }
+}

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -6,8 +6,6 @@
 
 import 'dart:convert';
 
-import 'package:http_parser/http_parser.dart';
-
 import 'message.dart';
 import 'utils.dart';
 
@@ -100,43 +98,4 @@ class Response extends Message {
       updatedContext,
     );
   }
-
-  /// The date and time after which the response's data should be considered
-  /// stale.
-  ///
-  /// This is parsed from the Expires header in [headers]. If [headers] doesn't
-  /// have an Expires header, this will be `null`.
-  DateTime get expires {
-    if (_expiresCache != null) {
-      return _expiresCache;
-    }
-
-    final expiresHeader = getHeader(headers, 'expires');
-    if (expiresHeader == null) {
-      return null;
-    }
-
-    return _expiresCache = parseHttpDate(expiresHeader);
-  }
-
-  DateTime _expiresCache;
-
-  /// The date and time the source of the response's data was last modified.
-  ///
-  /// This is parsed from the Last-Modified header in [headers]. If [headers]
-  /// doesn't have a Last-Modified header, this will be `null`.
-  DateTime get lastModified {
-    if (_lastModifiedCache != null) {
-      return _lastModifiedCache;
-    }
-
-    final lastModifiedHeader = getHeader(headers, 'last-modified');
-    if (lastModifiedHeader == null) {
-      return null;
-    }
-
-    return _lastModifiedCache = parseHttpDate(lastModifiedHeader);
-  }
-
-  DateTime _lastModifiedCache;
 }


### PR DESCRIPTION
Move the cache accessors from Response into an extension, CacheResponse.