### PR TITLE
refactor: Only accept Uri for url type

### DIFF
--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -56,7 +56,7 @@ class BrowserClient implements Client {
       // ignore: avoid_as
       final buffer = xhr.response as ByteBuffer;
       completer.complete(Response(
-        xhr.responseUrl,
+        Uri.parse(xhr.responseUrl),
         xhr.status,
         reasonPhrase: xhr.statusText,
         body: Stream.fromIterable([buffer.asUint8List()]),

--- a/lib/src/client_methods.dart
+++ b/lib/src/client_methods.dart
@@ -20,22 +20,20 @@ import 'response.dart';
 /// as an example if an API expects a body for a `DELETE` call, then a [Request]
 /// should be created manually and passed to [Client.send].
 extension ClientMethods on Client {
-  /// Sends an HTTP HEAD request with the given [headers] to the given [url],
-  /// which can be a [Uri] or a [String].
+  /// Sends an HTTP HEAD request with the given [headers] to the given [url].
   ///
   /// For more fine-grained control over the request, use [send] instead.
-  FutureOr<Response> head(Object url, {Map<String, String> headers}) =>
+  FutureOr<Response> head(Uri url, {Map<String, String> headers}) =>
       send(Request.head(url, headers: headers));
 
-  /// Sends an HTTP GET request with the given [headers] to the given [url],
-  /// which can be a [Uri] or a [String].
+  /// Sends an HTTP GET request with the given [headers] to the given [url].
   ///
   /// For more fine-grained control over the request, use [send] instead.
-  FutureOr<Response> get(Object url, {Map<String, String> headers}) =>
+  FutureOr<Response> get(Uri url, {Map<String, String> headers}) =>
       send(Request.get(url, headers: headers));
 
   /// Sends an HTTP POST request with the given [headers] and [body] to the
-  /// given [url], which can be a [Uri] or a [String].
+  /// given [url].
   ///
   /// [body] sets the body of the request. It can be a [String], or a
   /// [List<int>]. If it's a String, it's encoded using [encoding] and used as
@@ -49,7 +47,7 @@ extension ClientMethods on Client {
   ///
   /// For more fine-grained control over the request, use [send] instead.
   FutureOr<Response> post(
-    Object url,
+    Uri url,
     Object body, {
     Map<String, String> headers,
     Encoding encoding,
@@ -57,7 +55,7 @@ extension ClientMethods on Client {
       send(Request.post(url, body, headers: headers, encoding: encoding));
 
   /// Sends an HTTP PUT request with the given [headers] and [body] to the given
-  /// [url], which can be a [Uri] or a [String].
+  /// [url].
   ///
   /// [body] sets the body of the request. It can be a [String], or a
   /// [List<int>]. If it's a String, it's encoded using [encoding] and used as
@@ -71,7 +69,7 @@ extension ClientMethods on Client {
   ///
   /// For more fine-grained control over the request, use [send] instead.
   FutureOr<Response> put(
-    Object url,
+    Uri url,
     Object body, {
     Map<String, String> headers,
     Encoding encoding,
@@ -79,7 +77,7 @@ extension ClientMethods on Client {
       send(Request.put(url, body, headers: headers, encoding: encoding));
 
   /// Sends an HTTP PATCH request with the given [headers] and [body] to the
-  /// given [url], which can be a [Uri] or a [String].
+  /// given [url].
   ///
   /// [body] sets the body of the request. It can be a [String], or a
   /// [List<int>]. If it's a String, it's encoded using [encoding] and used as
@@ -93,17 +91,16 @@ extension ClientMethods on Client {
   ///
   /// For more fine-grained control over the request, use [send] instead.
   FutureOr<Response> patch(
-    Object url,
+    Uri url,
     Object body, {
     Map<String, String> headers,
     Encoding encoding,
   }) =>
       send(Request.patch(url, body, headers: headers, encoding: encoding));
 
-  /// Sends an HTTP DELETE request with the given [headers] to the given [url],
-  /// which can be a [Uri] or a [String].
+  /// Sends an HTTP DELETE request with the given [headers] to the given [url].
   ///
   /// For more fine-grained control over the request, use [send] instead.
-  FutureOr<Response> delete(Object url, {Map<String, String> headers}) =>
+  FutureOr<Response> delete(Uri url, {Map<String, String> headers}) =>
       send(Request.delete(url, headers: headers));
 }

--- a/lib/src/client_reader.dart
+++ b/lib/src/client_reader.dart
@@ -15,30 +15,28 @@ import 'exception.dart';
 import 'json_message.dart';
 import 'response.dart';
 import 'text_message.dart';
-import 'utils.dart';
 
 /// Convenience methods for HTTP GET requests that return the body of the
 /// [Response].
 extension ClientReader on Client {
-  /// Sends an HTTP GET request with the given [headers] to the given [url],
-  /// which can be a [Uri] or a [String], and returns a Future that completes
-  /// to the body of the response as a [String].
+  /// Sends an HTTP GET request with the given [headers] to the given [url] and
+  /// returns a Future that completes to the body of the response as a [String].
   ///
   /// The Future will emit a [ClientException] if the response doesn't have a
   /// success status code.
   ///
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
-  FutureOr<String> read(Object url, {Map<String, String> headers}) async {
+  FutureOr<String> read(Uri url, {Map<String, String> headers}) async {
     final response = await get(url, headers: headers);
     _checkResponseSuccess(url, response);
 
     return response.readAsString();
   }
 
-  /// Sends an HTTP GET request with the given [headers] to the given [url],
-  /// which can be a [Uri] or a [String], and returns a Future that completes
-  /// to the body of the response as a list of bytes.
+  /// Sends an HTTP GET request with the given [headers] to the given [url] and
+  /// returns a Future that completes to the body of the response as a list of
+  /// bytes.
   ///
   /// The Future will emit a [ClientException] if the response doesn't have a
   /// success status code.
@@ -46,7 +44,7 @@ extension ClientReader on Client {
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
   FutureOr<Uint8List> readBytes(
-    Object url, {
+    Uri url, {
     Map<String, String> headers,
   }) async {
     final response = await get(url, headers: headers);
@@ -55,16 +53,15 @@ extension ClientReader on Client {
     return collectBytes(response.read());
   }
 
-  /// Sends an HTTP GET request with the given [headers] to the given [url],
-  /// which can be a [Uri] or a [String], and returns a Future that completes
-  /// to the body of the response as a JSON.
+  /// Sends an HTTP GET request with the given [headers] to the given [url], and
+  /// returns a Future that completes to the body of the response as a JSON.
   ///
   /// The Future will emit a [ClientException] if the response doesn't have a
   /// success status code.
   ///
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
-  FutureOr<T> readJson<T>(Object url, {Map<String, String> headers}) async {
+  FutureOr<T> readJson<T>(Uri url, {Map<String, String> headers}) async {
     final response = await get(url, headers: headers);
     _checkResponseSuccess(url, response);
 
@@ -72,7 +69,7 @@ extension ClientReader on Client {
   }
 
   /// Throws an error if [response] is not successful.
-  static void _checkResponseSuccess(Object url, Response response) {
+  static void _checkResponseSuccess(Uri url, Response response) {
     if (response.statusCode < 400) {
       return;
     }
@@ -81,6 +78,6 @@ extension ClientReader on Client {
     if (response.reasonPhrase.isNotEmpty) {
       message = '$message: ${response.reasonPhrase}';
     }
-    throw ClientException('$message.', getUrl(url));
+    throw ClientException('$message.', url);
   }
 }

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -16,8 +16,7 @@ import 'utils.dart';
 
 /// Represents an HTTP request to be sent to a server.
 class Request extends Message {
-  /// Creates a new [Request] for [url], which can be a [Uri] or a [String],
-  /// using [method].
+  /// Creates a new [Request] for a [url] using the HTTP [method].
   ///
   /// [body] is the request body. It may be either a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
@@ -31,14 +30,14 @@ class Request extends Message {
   /// and handlers.
   Request(
     String method,
-    Object url, {
+    Uri url, {
     Object body,
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,
-  }) : this._(method, getUrl(url), body, encoding, headers, context);
+  }) : this._(method, url, body, encoding, headers, context);
 
-  /// Creates a new HEAD [Request] to [url], which can be a [Uri] or a [String].
+  /// Creates a new HEAD [Request] for a [url].
   ///
   /// [headers] are the HTTP headers for the request. If [headers] is `null`,
   /// it is treated as empty.
@@ -46,12 +45,12 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   Request.head(
-    Object url, {
+    Uri url, {
     Map<String, String> headers,
     Map<String, Object> context,
   }) : this(MethodToken.head, url, headers: headers, context: context);
 
-  /// Creates a new GET [Request] to [url], which can be a [Uri] or a [String].
+  /// Creates a new GET [Request] for a [url].
   ///
   /// [headers] are the HTTP headers for the request. If [headers] is `null`,
   /// it is treated as empty.
@@ -59,12 +58,12 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   Request.get(
-    Object url, {
+    Uri url, {
     Map<String, String> headers,
     Map<String, Object> context,
   }) : this(MethodToken.get, url, headers: headers, context: context);
 
-  /// Creates a new POST [Request] to [url], which can be a [Uri] or a [String].
+  /// Creates a new POST [Request] for a [url].
   ///
   /// [body] is the request body. It may be either a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
@@ -77,7 +76,7 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   Request.post(
-    Object url,
+    Uri url,
     Object body, {
     Encoding encoding,
     Map<String, String> headers,
@@ -91,7 +90,7 @@ class Request extends Message {
           context: context,
         );
 
-  /// Creates a new PUT [Request] to [url], which can be a [Uri] or a [String].
+  /// Creates a new PUT [Request] for a [url].
   ///
   /// [body] is the request body. It may be either a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
@@ -104,7 +103,7 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   Request.put(
-    Object url,
+    Uri url,
     Object body, {
     Encoding encoding,
     Map<String, String> headers,
@@ -118,8 +117,7 @@ class Request extends Message {
           context: context,
         );
 
-  /// Creates a new PATCH [Request] to [url], which can be a [Uri] or a
-  /// [String].
+  /// Creates a new PATCH [Request] for a [url].
   ///
   /// [body] is the request body. It may be either a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
@@ -132,7 +130,7 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   Request.patch(
-    Object url,
+    Uri url,
     Object body, {
     Encoding encoding,
     Map<String, String> headers,
@@ -146,8 +144,7 @@ class Request extends Message {
           context: context,
         );
 
-  /// Creates a new DELETE [Request] to [url], which can be a [Uri] or a
-  /// [String].
+  /// Creates a new DELETE [Request] for a [url].
   ///
   /// [headers] are the HTTP headers for the request. If [headers] is `null`,
   /// it is treated as empty.
@@ -155,13 +152,13 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   Request.delete(
-    Object url, {
+    Uri url, {
     Map<String, String> headers,
     Map<String, Object> context,
   }) : this(MethodToken.delete, url, headers: headers, context: context);
 
   /// Creates a new [`application/json`](https://www.ietf.org/rfc/rfc4627.txt)
-  /// [Request] to the [url], which can be a [Uri] or a [String].
+  /// [Request] for a [url].
   ///
   /// The [body] is converted using a [JsonEncoder] into a [String]. [encoding]
   /// is used to encode the values in the body. It defaults to UTF-8.
@@ -174,7 +171,7 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   factory Request.json(
-    Object url,
+    Uri url,
     Object body, {
     String method,
     Encoding encoding,
@@ -183,7 +180,7 @@ class Request extends Message {
   }) =>
       Request._(
         method ?? MethodToken.post,
-        getUrl(url),
+        url,
         jsonEncode(body),
         encoding ?? utf8,
         updateMap(
@@ -195,7 +192,7 @@ class Request extends Message {
 
   /// Creates a new
   /// [`multipart/form-data`](https://en.wikipedia.org/wiki/MIME#Multipart_messages)
-  /// [Request] to [url], which can be a [Uri] or a [String].
+  /// [Request] for a [url].
   ///
   /// The content of the body is specified through the values of [fields] and
   /// [files]. The name for a field can be reused so the [fields] type is
@@ -212,7 +209,7 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   factory Request.multipart(
-    Object url, {
+    Uri url, {
     String method,
     Map<String, String> headers,
     Map<String, Object> context,
@@ -226,7 +223,7 @@ class Request extends Message {
 
     return Request._(
       method ?? MethodToken.post,
-      getUrl(url),
+      url,
       MultipartBody(fields, files, boundary),
       null,
       updateMap(
@@ -241,7 +238,7 @@ class Request extends Message {
 
   /// Creates a new
   /// [`multipart/form-data`](https://en.wikipedia.org/wiki/MIME#Multipart_messages)
-  /// [Request] to [url], which can be a [Uri] or a [String].
+  /// [Request] for a [url].
   ///
   /// The [body] is a map of strings with the values. [encoding] is used to
   /// encode the values in the body. It defaults to UTF-8.
@@ -254,7 +251,7 @@ class Request extends Message {
   /// Extra [context] can be used to pass information between inner middleware
   /// and handlers.
   factory Request.urlEncoded(
-    Object url,
+    Uri url,
     Map<String, String> body, {
     String method,
     Encoding encoding,
@@ -271,7 +268,7 @@ class Request extends Message {
 
     return Request._(
       method ?? MethodToken.post,
-      getUrl(url),
+      url,
       pairs.map((pair) => '${pair[0]}=${pair[1]}').join('&'),
       null,
       updateMap(

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -12,8 +12,8 @@ import 'utils.dart';
 
 /// An HTTP response where the entire response body is known in advance.
 class Response extends Message {
-  /// Creates a new HTTP response for a resource at the [finalUrl], which can
-  /// be a [Uri] or a [String], with the given [statusCode].
+  /// Creates a new HTTP response for a resource at the [finalUrl] with the
+  /// given [statusCode].
   ///
   /// [body] is the request body. It may be either a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null` to indicate no body. If it's a [String],
@@ -26,7 +26,7 @@ class Response extends Message {
   /// Extra [context] can be used to pass information between outer middleware
   /// and handlers.
   Response(
-    Object finalUrl,
+    Uri finalUrl,
     int statusCode, {
     String reasonPhrase,
     Object body,
@@ -34,7 +34,7 @@ class Response extends Message {
     Map<String, String> headers,
     Map<String, Object> context,
   }) : this._(
-          getUrl(finalUrl),
+          finalUrl,
           statusCode,
           reasonPhrase ?? '',
           body,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -50,16 +50,3 @@ String getHeader(Map<String, String> headers, String name) {
   }
   return null;
 }
-
-/// Returns a [Uri] from the [url], which can be a [Uri] or a [String].
-///
-/// If the [url] is not a [Uri] or [String] an [ArgumentError] is thrown.
-Uri getUrl(Object url) {
-  if (url is Uri) {
-    return url;
-  } else if (url is String) {
-    return Uri.parse(url);
-  } else {
-    throw ArgumentError.value(url, 'url', 'Not a Uri or String');
-  }
-}


### PR DESCRIPTION
Shift the responsibility of converting a String to a Uri to the caller. This allows for better type checking within the library.