### PR TITLE
feat: Add enumeration for HTTP methods

### DIFF
--- a/lib/http.dart
+++ b/lib/http.dart
@@ -12,6 +12,7 @@ export 'src/client_methods.dart';
 export 'src/client_reader.dart';
 export 'src/exception.dart';
 export 'src/handler.dart';
+export 'src/method.dart';
 export 'src/middleware.dart';
 export 'src/multipart_file.dart';
 export 'src/pipeline.dart';

--- a/lib/src/method.dart
+++ b/lib/src/method.dart
@@ -1,0 +1,98 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+/// Indicate the desired action to be performed for a given resource as
+/// specified by the HTTP standard.
+enum Method {
+  /// The `GET` method requests a representation of the specified resource.
+  ///
+  /// Requests using `GET` should only retrieve data.
+  get,
+
+  /// The `HEAD` method asks for a response identical to that of a GET request,
+  /// but without the response body.
+  head,
+
+  /// The `POST` method is used to submit an entity to the specified resource,
+  /// often causing a change in state or side effects on the server.
+  post,
+
+  /// The `PUT` method replaces all current representations of the target
+  /// resource with the request payload.
+  put,
+
+  /// The `PATCH` method is used to apply partial modifications to a resource.
+  patch,
+
+  /// The `DELETE` method deletes the specified resource.
+  delete,
+
+  /// The `CONNECT` method establishes a tunnel to the server identified by
+  /// the target resource.
+  connect,
+
+  /// The `OPTIONS` method is used to describe the communication options for
+  /// the target resource.
+  options,
+
+  /// The `TRACE` method performs a message loop-back test along the path to
+  /// the target resource.
+  trace,
+}
+
+/// Mapping from a [Method] to a recognized token for the action.
+extension MethodToken on Method {
+  /// Token for a [Method.get] request.
+  static const String get = 'GET';
+
+  /// Token for a [Method.head] request.
+  static const String head = 'HEAD';
+
+  /// Token for a [Method.post] request.
+  static const String post = 'POST';
+
+  /// Token for a [Method.put] request.
+  static const String put = 'PUT';
+
+  /// Token for a [Method.patch] request.
+  static const String patch = 'PATCH';
+
+  /// Token for a [Method.delete] request.
+  static const String delete = 'DELETE';
+
+  /// Token for a [Method.connect] request.
+  static const String connect = 'CONNECT';
+
+  /// Token for a [Method.options] request.
+  static const String options = 'OPTIONS';
+
+  /// Token for a [Method.trace] request.
+  static const String trace = 'TRACE';
+
+  /// Retrieves the token associated with the [Method].
+  String get token {
+    switch (this) {
+      case Method.get:
+        return get;
+      case Method.head:
+        return head;
+      case Method.post:
+        return post;
+      case Method.put:
+        return put;
+      case Method.patch:
+        return patch;
+      case Method.delete:
+        return delete;
+      case Method.connect:
+        return connect;
+      case Method.options:
+        return options;
+      case Method.trace:
+        return trace;
+    }
+    return '';
+  }
+}

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 
 import 'boundary.dart';
 import 'message.dart';
+import 'method.dart';
 import 'multipart_body.dart';
 import 'multipart_file.dart';
 import 'utils.dart';
@@ -47,7 +48,7 @@ class Request extends Message {
     Object url, {
     Map<String, String> headers,
     Map<String, Object> context,
-  }) : this('HEAD', url, headers: headers, context: context);
+  }) : this(MethodToken.head, url, headers: headers, context: context);
 
   /// Creates a new GET [Request] to [url], which can be a [Uri] or a [String].
   ///
@@ -60,7 +61,7 @@ class Request extends Message {
     Object url, {
     Map<String, String> headers,
     Map<String, Object> context,
-  }) : this('GET', url, headers: headers, context: context);
+  }) : this(MethodToken.get, url, headers: headers, context: context);
 
   /// Creates a new POST [Request] to [url], which can be a [Uri] or a [String].
   ///
@@ -80,8 +81,14 @@ class Request extends Message {
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,
-  }) : this('POST', url,
-            body: body, encoding: encoding, headers: headers, context: context);
+  }) : this(
+          MethodToken.post,
+          url,
+          body: body,
+          encoding: encoding,
+          headers: headers,
+          context: context,
+        );
 
   /// Creates a new PUT [Request] to [url], which can be a [Uri] or a [String].
   ///
@@ -101,8 +108,14 @@ class Request extends Message {
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,
-  }) : this('PUT', url,
-            body: body, encoding: encoding, headers: headers, context: context);
+  }) : this(
+          MethodToken.put,
+          url,
+          body: body,
+          encoding: encoding,
+          headers: headers,
+          context: context,
+        );
 
   /// Creates a new PATCH [Request] to [url], which can be a [Uri] or a
   /// [String].
@@ -123,8 +136,14 @@ class Request extends Message {
     Encoding encoding,
     Map<String, String> headers,
     Map<String, Object> context,
-  }) : this('PATCH', url,
-            body: body, encoding: encoding, headers: headers, context: context);
+  }) : this(
+          MethodToken.patch,
+          url,
+          body: body,
+          encoding: encoding,
+          headers: headers,
+          context: context,
+        );
 
   /// Creates a new DELETE [Request] to [url], which can be a [Uri] or a
   /// [String].
@@ -138,7 +157,7 @@ class Request extends Message {
     Object url, {
     Map<String, String> headers,
     Map<String, Object> context,
-  }) : this('DELETE', url, headers: headers, context: context);
+  }) : this(MethodToken.delete, url, headers: headers, context: context);
 
   /// Creates a new [`application/json`](https://www.ietf.org/rfc/rfc4627.txt)
   /// [Request] to the [url], which can be a [Uri] or a [String].
@@ -162,7 +181,7 @@ class Request extends Message {
     Map<String, Object> context,
   }) =>
       Request._(
-        method ?? 'POST',
+        method ?? MethodToken.post,
         getUrl(url),
         jsonEncode(body),
         encoding ?? utf8,
@@ -205,7 +224,7 @@ class Request extends Message {
     boundary ??= boundaryString();
 
     return Request._(
-      method ?? 'POST',
+      method ?? MethodToken.post,
       getUrl(url),
       MultipartBody(fields, files, boundary),
       null,
@@ -250,7 +269,7 @@ class Request extends Message {
         ]));
 
     return Request._(
-      method ?? 'POST',
+      method ?? MethodToken.post,
       getUrl(url),
       pairs.map((pair) => '${pair[0]}=${pair[1]}').join('&'),
       null,


### PR DESCRIPTION
Expose an enumeration for all the standard HTTP methods. Provide an extension which maps the enumeration to the token name.