### PR TITLE
refactor: Create an extension for content headers

### DIFF
--- a/lib/src/content_headers.dart
+++ b/lib/src/content_headers.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'mime_types.dart';
+
+/// Helpers for setting headers around the content of the message.
+extension ContentHeaders on Map<String, String> {
+  static const String _contentLengthHeader = 'content-length';
+  static const String _contentTypeHeader = 'content-type';
+
+  /// Returns an immutable map containing a `content-type` header for JSON
+  /// data.
+  static Map<String, String> json() => const <String, String>{
+        _contentTypeHeader: '$applicationType/$jsonSubtype',
+      };
+
+  /// Returns an immutable map containing a `content-type` header for multi-part
+  /// form data.
+  static Map<String, String> multipart(String boundary) => <String, String>{
+        _contentTypeHeader: 'multipart/form-data; boundary=$boundary',
+      };
+
+  /// Returns an immutable map containing a `content-type` header for url
+  /// encoded form data.
+  static Map<String, String> urlEncoded() => const <String, String>{
+        _contentTypeHeader: '$applicationType/x-www-form-urlencoded',
+      };
+
+  /// The `content-length` header value.
+  String get contentLength => this[_contentLengthHeader];
+  set contentLength(String value) {
+    _setOrRemove(_contentLengthHeader, value);
+  }
+
+  /// The `content-type` header value.
+  String get contentType => this[_contentTypeHeader];
+  set contentType(String value) {
+    _setOrRemove(_contentTypeHeader, value);
+  }
+
+  void _setOrRemove(String key, String value) {
+    if (value == null) {
+      remove(key);
+    } else {
+      this[key] = value;
+    }
+  }
+}

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -13,6 +13,7 @@ import 'package:http_parser/http_parser.dart';
 import 'package:meta/meta.dart';
 
 import 'body.dart';
+import 'content_headers.dart';
 import 'context.dart';
 import 'http_unmodifiable_map.dart';
 import 'media_type_encoding.dart';
@@ -91,7 +92,7 @@ abstract class Message {
       return _contentLengthCache;
     }
 
-    final contentLengthHeader = getHeader(headers, 'content-length');
+    final contentLengthHeader = headers.contentLength;
     if (contentLengthHeader == null) {
       // ignore: avoid_returning_null
       return null;
@@ -127,7 +128,7 @@ abstract class Message {
       return _contentTypeCache;
     }
 
-    final contentTypeHeader = getHeader(headers, 'content-type');
+    final contentTypeHeader = headers.contentType;
     if (contentTypeHeader == null) {
       return null;
     }
@@ -193,10 +194,10 @@ abstract class Message {
 
     final newHeaders = CaseInsensitiveMap<String>.from(headers ?? const {});
     if (contentType != null) {
-      newHeaders['content-type'] = contentType;
+      newHeaders.contentType = contentType;
     }
     if (contentLength != null) {
-      newHeaders['content-length'] = contentLength;
+      newHeaders.contentLength = contentLength;
     }
     return newHeaders;
   }
@@ -212,7 +213,7 @@ abstract class Message {
     }
 
     final contentLengthHeader = bodyLength.toString();
-    if (contentLengthHeader == getHeader(headers, 'content-length')) {
+    if (contentLengthHeader == headers.contentLength) {
       return null;
     }
 
@@ -233,7 +234,7 @@ abstract class Message {
   /// Returns the value for the `content-type` header if it should be
   /// modified, otherwise it returns `null`.
   static String _contentTypeHeader(Map<String, String> headers, Body body) {
-    final contentTypeHeader = getHeader(headers, 'content-type');
+    final contentTypeHeader = headers.contentType;
     var changed = false;
     MediaType mediaType;
     Encoding mediaEncoding;

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -7,6 +7,7 @@
 import 'dart:convert';
 
 import 'boundary.dart';
+import 'content_headers.dart';
 import 'context.dart';
 import 'message.dart';
 import 'method.dart';
@@ -183,10 +184,7 @@ class Request extends Message {
         url,
         jsonEncode(body),
         encoding ?? utf8,
-        updateMap(
-          const <String, String>{'content-type': 'application/json'},
-          headers,
-        ),
+        updateMap(ContentHeaders.json(), headers),
         context,
       );
 
@@ -226,12 +224,7 @@ class Request extends Message {
       url,
       MultipartBody(fields, files, boundary),
       null,
-      updateMap(
-        <String, String>{
-          'content-type': 'multipart/form-data; boundary=$boundary'
-        },
-        headers,
-      ),
+      updateMap(ContentHeaders.multipart(boundary), headers),
       context,
     );
   }
@@ -271,12 +264,7 @@ class Request extends Message {
       url,
       pairs.map((pair) => '${pair[0]}=${pair[1]}').join('&'),
       null,
-      updateMap(
-        const <String, String>{
-          'content-type': 'application/x-www-form-urlencoded'
-        },
-        headers,
-      ),
+      updateMap(ContentHeaders.urlEncoded(), headers),
       context,
     );
   }


### PR DESCRIPTION
Provide a way to set and get content-length and content-type on headers easily.