### PR TITLE
refactor: Use an extension for Message headers

### DIFF
--- a/lib/src/headers.dart
+++ b/lib/src/headers.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2020, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'package:collection/collection.dart';
+import 'package:http_parser/http_parser.dart';
+
+import 'body.dart';
+import 'content_headers.dart';
+import 'http_unmodifiable_map.dart';
+import 'media_type_encoding.dart';
+import 'mime_types.dart';
+
+/// Helpers for manipulating [Message.headers] values.
+extension Headers on Map<String, String> {
+  /// Creates a [HttpUnmodifiableMap] from the [source] while preventing
+  /// re-wrapping itself.
+  ///
+  /// If [source] is already a [HttpUnmodifiableMap] then it is returned
+  /// unchanged.
+  ///
+  /// If [source] is `null` it is treated as an empty map.
+  ///
+  /// When creating a [HttpUnmodifiableMap] the [source] is copies to a new
+  /// [Map] to ensure changes to the parameter value after constructions are
+  /// not reflected.
+  static Map<String, String> create(Map<String, String> source) {
+    if (source is HttpUnmodifiableMap<String>) {
+      return source;
+    }
+
+    return source == null || source.isEmpty
+        ? const HttpUnmodifiableMap<String>.empty()
+        : HttpUnmodifiableMap<String>(
+            Map<String, String>.from(source),
+            ignoreKeyCase: true,
+          );
+  }
+
+  /// Returns a [HttpUnmodifiableMap] with the values from [original] and the
+  /// values from [updates].
+  ///
+  /// For keys that are the same between [original] and [updates], the value in
+  /// [updates] is used.
+  static Map<String, String> update(
+    Map<String, String> original,
+    Map<String, String> updates,
+  ) {
+    if (updates == null || updates.isEmpty) {
+      return create(original);
+    }
+
+    return HttpUnmodifiableMap<String>(
+      Map<String, String>.from(original)..addAll(updates),
+      ignoreKeyCase: true,
+    );
+  }
+
+  /// Adjusts the [headers] information about content based on the [body].
+  ///
+  /// Returns a new map without modifying [headers].
+  static Map<String, String> adjust(Map<String, String> headers, Body body) {
+    assert(headers is HttpUnmodifiableMap, 'headers are unmodifiable');
+
+    final contentLengthHeader = _contentLengthHeader(headers, body);
+    final contentTypeHeader = _contentTypeHeader(headers, body);
+
+    final contentLengthSame = contentLengthHeader == headers.contentLength;
+    final contentTypeSame = contentTypeHeader == headers.contentType;
+
+    if (contentLengthSame && contentTypeSame) {
+      return headers;
+    }
+
+    // The keys for headers are case-insensitive already so just use a map
+    final updatedHeaders = Map<String, String>.from(headers);
+    if (!contentLengthSame) {
+      updatedHeaders.contentLength = contentLengthHeader;
+    }
+    if (!contentTypeSame) {
+      updatedHeaders.contentType = contentTypeHeader;
+    }
+
+    return create(updatedHeaders);
+  }
+
+  static String _contentLengthHeader(Map<String, String> headers, Body body) {
+    final contentLengthHeader = headers.contentLength;
+    final bodyLength = body.contentLength;
+    if (bodyLength == null || bodyLength == 0) {
+      return contentLengthHeader;
+    }
+
+    final bodyLengthString = bodyLength.toString();
+    if (bodyLengthString == contentLengthHeader) {
+      return contentLengthHeader;
+    }
+
+    final coding = headers['transfer-encoding'];
+    return coding == null || equalsIgnoreAsciiCase(coding, 'identity')
+        ? bodyLengthString
+        : contentLengthHeader;
+  }
+
+  static String _contentTypeHeader(Map<String, String> headers, Body body) {
+    final contentTypeHeader = headers.contentType;
+    final mediaType = contentTypeHeader != null
+        ? MediaType.parse(contentTypeHeader)
+        : octetStreamMediaType();
+
+    final mediaEncoding = mediaType.encoding;
+    final useEncoding = body.encoding ?? mediaEncoding;
+
+    return useEncoding == mediaEncoding
+        ? contentTypeHeader
+        : mediaType.changeEncoding(useEncoding).toString();
+  }
+}

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -9,11 +9,11 @@ import 'dart:convert';
 import 'boundary.dart';
 import 'content_headers.dart';
 import 'context.dart';
+import 'headers.dart';
 import 'message.dart';
 import 'method.dart';
 import 'multipart_body.dart';
 import 'multipart_file.dart';
-import 'utils.dart';
 
 /// Represents an HTTP request to be sent to a server.
 class Request extends Message {
@@ -184,7 +184,7 @@ class Request extends Message {
         url,
         jsonEncode(body),
         encoding ?? utf8,
-        updateMap(ContentHeaders.json(), headers),
+        Headers.update(ContentHeaders.json(), headers),
         context,
       );
 
@@ -224,7 +224,7 @@ class Request extends Message {
       url,
       MultipartBody(fields, files, boundary),
       null,
-      updateMap(ContentHeaders.multipart(boundary), headers),
+      Headers.update(ContentHeaders.multipart(boundary), headers),
       context,
     );
   }
@@ -264,7 +264,7 @@ class Request extends Message {
       url,
       pairs.map((pair) => '${pair[0]}=${pair[1]}').join('&'),
       null,
-      updateMap(ContentHeaders.urlEncoded(), headers),
+      Headers.update(ContentHeaders.urlEncoded(), headers),
       context,
     );
   }
@@ -304,7 +304,7 @@ class Request extends Message {
     Map<String, Object> context,
     Object body,
   }) {
-    final updatedHeaders = updateMap(this.headers, headers);
+    final updatedHeaders = Headers.update(this.headers, headers);
     final updatedContext = Context.update(this.context, context);
 
     return Request._(

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -7,8 +7,8 @@
 import 'dart:convert';
 
 import 'context.dart';
+import 'headers.dart';
 import 'message.dart';
-import 'utils.dart';
 
 /// An HTTP response where the entire response body is known in advance.
 class Response extends Message {
@@ -86,7 +86,7 @@ class Response extends Message {
     Map<String, Object> context,
     Object body,
   }) {
-    final updatedHeaders = updateMap(this.headers, headers);
+    final updatedHeaders = Headers.update(this.headers, headers);
     final updatedContext = Context.update(this.context, context);
 
     return Response._(

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -4,25 +4,6 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-import 'package:collection/collection.dart';
-
-import 'http_unmodifiable_map.dart';
-
-/// Returns a [Map] with the values from [original] and the values from
-/// [updates].
-///
-/// For keys that are the same between [original] and [updates], the value in
-/// [updates] is used.
-///
-/// If [updates] is `null` or empty, [original] is returned unchanged.
-Map<K, V> updateMap<K, V>(Map<K, V> original, Map<K, V> updates) {
-  if (updates == null || updates.isEmpty) {
-    return original;
-  }
-
-  return Map<K, V>.from(original)..addAll(updates);
-}
-
 /// A regular expression that matches strings that are composed entirely of
 /// ASCII-compatible characters.
 final RegExp _asciiOnly = RegExp(r'^[\x00-\x7F]+$');
@@ -30,23 +11,3 @@ final RegExp _asciiOnly = RegExp(r'^[\x00-\x7F]+$');
 /// Returns whether [string] is composed entirely of ASCII-compatible
 /// characters.
 bool isPlainAscii(String string) => _asciiOnly.hasMatch(string);
-
-/// Returns the header with the given [name] in [headers].
-///
-/// This works even if [headers] is `null`, or if it's not yet a
-/// case-insensitive map.
-String getHeader(Map<String, String> headers, String name) {
-  if (headers == null) {
-    return null;
-  }
-  if (headers is HttpUnmodifiableMap) {
-    return headers[name];
-  }
-
-  for (final key in headers.keys) {
-    if (equalsIgnoreAsciiCase(key, name)) {
-      return headers[key];
-    }
-  }
-  return null;
-}

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-@Skip('this test does not complete in the CI')
-
 import 'dart:convert';
 
 import 'package:test/test.dart';

--- a/test/message_change_test.dart
+++ b/test/message_change_test.dart
@@ -86,15 +86,14 @@ void _testChange(
     final request = factory(headers: {'test': 'test value'});
     final copy = request.change(headers: {'test2': 'test2 value'});
 
-    expect(copy.headers,
-        {'test': 'test value', 'test2': 'test2 value', 'content-length': '0'});
+    expect(copy.headers, {'test': 'test value', 'test2': 'test2 value'});
   });
 
   test('existing header values are overwritten', () {
     final request = factory(headers: {'test': 'test value'});
     final copy = request.change(headers: {'test': 'new test value'});
 
-    expect(copy.headers, {'test': 'new test value', 'content-length': '0'});
+    expect(copy.headers, {'test': 'new test value'});
   });
 
   test('new context values are added', () {

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -62,8 +62,7 @@ void main() {
 
     test('default to a constant map', () {
       final message = _createMessage();
-      expect(message.headers, hasLength(1));
-      expect(message.headers.containsKey('content-length'), isTrue);
+      expect(message.headers.containsKey('content-length'), isFalse);
       expect(message.headers, same(_createMessage().headers));
       expect(() => message.headers['h1'] = 'value1', throwsUnsupportedError);
     });
@@ -181,9 +180,9 @@ void main() {
   });
 
   group('content-length', () {
-    test('is 0 with a default body and without a content-length header', () {
-      final request = _createMessage();
-      expect(request.contentLength, 0);
+    test('is null with a default body and without a content-length header', () {
+      final message = _createMessage();
+      expect(message.contentLength, isNull);
     });
 
     test('comes from a byte body', () {


### PR DESCRIPTION
Move all header related functionality from Message into the Headers extension. Simplified the adjusting of headers.

A content-length header is no longer sent if the content-length is 0.

Update tests accordingly.