### PR TITLE
ci: Try 2.11 Dart images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,7 @@ steps:
   - name: cache
     path: /root/.pub-cache
   commands:
-    - dart run test --coverage coverage
+    - pub run test --coverage coverage
 
 - name: generate-lcov
   image: google/dart:2.11-beta
@@ -44,7 +44,7 @@ steps:
   - name: cache
     path: /root/.pub-cache
   commands:
-    - dart pub global activate coverage
+    - pub global activate coverage
     - format_coverage --verbose --lcov --packages .packages --base-directory . --report-on lib --report-on test --in coverage --out coverage/lcov.cov
 
 - name: upload-coverage

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: dart-dev
 
 steps:
 - name: environment
-  image: google/dart:2.11-beta
+  image: google/dart:beta
   pull: always
   volumes:
   - name: cache
@@ -13,7 +13,7 @@ steps:
     - dart --version
 
 - name: dependencies
-  image: google/dart:2.11-beta
+  image: google/dart:beta
   volumes:
   - name: cache
     path: /root/.pub-cache
@@ -21,7 +21,7 @@ steps:
     - dart pub get
 
 - name: lint
-  image: google/dart:2.11-beta
+  image: google/dart:beta
   volumes:
   - name: cache
     path: /root/.pub-cache
@@ -30,7 +30,7 @@ steps:
     - dart analyze test
 
 - name: test
-  image: google/dart:2.11-beta
+  image: google/dart:beta
   failure: ignore # TODO: Remove after tests fixed
   volumes:
   - name: cache
@@ -39,7 +39,7 @@ steps:
     - pub run test --coverage coverage
 
 - name: generate-lcov
-  image: google/dart:2.11-beta
+  image: google/dart:beta
   volumes:
   - name: cache
     path: /root/.pub-cache

--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,7 @@ steps:
   - name: cache
     path: /root/.pub-cache
   commands:
-    - pub run test --coverage coverage
+    - dart run test --coverage coverage
 
 - name: generate-lcov
   image: google/dart:beta
@@ -44,7 +44,7 @@ steps:
   - name: cache
     path: /root/.pub-cache
   commands:
-    - pub global activate coverage
+    - dart pub global activate coverage
     - format_coverage --verbose --lcov --packages .packages --base-directory . --report-on lib --report-on test --in coverage --out coverage/lcov.cov
 
 - name: upload-coverage

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: dart-dev
 
 steps:
 - name: environment
-  image: google/dart:dev
+  image: google/dart:2.11-beta
   pull: always
   volumes:
   - name: cache
@@ -13,7 +13,7 @@ steps:
     - dart --version
 
 - name: dependencies
-  image: google/dart:dev
+  image: google/dart:2.11-beta
   volumes:
   - name: cache
     path: /root/.pub-cache
@@ -21,7 +21,7 @@ steps:
     - dart pub get
 
 - name: lint
-  image: google/dart:dev
+  image: google/dart:2.11-beta
   volumes:
   - name: cache
     path: /root/.pub-cache
@@ -30,7 +30,7 @@ steps:
     - dart analyze test
 
 - name: test
-  image: google/dart:dev
+  image: google/dart:2.11-beta
   failure: ignore # TODO: Remove after tests fixed
   volumes:
   - name: cache
@@ -39,7 +39,7 @@ steps:
     - dart run test --coverage coverage
 
 - name: generate-lcov
-  image: google/dart:dev
+  image: google/dart:2.11-beta
   volumes:
   - name: cache
     path: /root/.pub-cache


### PR DESCRIPTION
Running `test` was very consistent prior to 2.12. Since then running `test` in the container does not successfully exit.