### PR TITLE
ci: Update CI configuration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,48 +4,56 @@ name: dart-dev
 
 steps:
 - name: environment
-  image: google/dart:dev
+  image: google/dart:beta
   pull: always
   volumes:
   - name: cache
     path: /root/.pub-cache
   commands:
-    - dart --version
+  - dart --version
 
 - name: dependencies
-  image: google/dart:dev
+  image: google/dart:beta
   volumes:
   - name: cache
     path: /root/.pub-cache
   commands:
-    - dart pub get
+  - dart pub get
+
+- name: format
+  image: google/dart:beta
+  volumes:
+  - name: cache
+    path: /root/.pub-cache
+  commands:
+  - dart format --set-exit-if-changed .
 
 - name: lint
-  image: google/dart:dev
+  image: google/dart:beta
   volumes:
   - name: cache
     path: /root/.pub-cache
   commands:
-    - dart analyze lib
-    - dart analyze test
+  - dart analyze lib
+  - dart analyze test
 
 - name: test
-  image: google/dart:dev
-  failure: ignore # TODO: Remove after tests fixed
+  image: google/dart:beta
   volumes:
   - name: cache
     path: /root/.pub-cache
   commands:
-    - dart run test --coverage coverage
+  # Using `pub run test` is deprecated but this step using `dart run test` does not complete
+  - pub run test --coverage coverage
 
 - name: generate-lcov
-  image: google/dart:dev
+  image: google/dart:beta
   volumes:
   - name: cache
     path: /root/.pub-cache
   commands:
-    - dart pub global activate coverage
-    - format_coverage --verbose --lcov --packages .packages --base-directory . --report-on lib --report-on test --in coverage --out coverage/lcov.cov
+  - dart pub global activate coverage
+  - format_coverage --verbose --lcov --packages .packages --base-directory . --report-on lib --report-on test --in coverage --out coverage/lcov.cov
 
 - name: upload-coverage
   image: plugins/codecov


### PR DESCRIPTION
Use the `dart:beta` docker images. This will still be bleeding edge but will have a bit more stability than the `dart:dev` docker images.

Add an additional step that verifies that `dart format` was successful so formatting errors are not introduced.

Investigations showed that when `dart run test` is used for the `test` step it almost never completes. Use `pub run test` instead even though its deprecated since it makes the step actually run to completion.

Also don't ignore test failures anymore since all tests are now passing.