### PR TITLE
refactor: Move isMimeType onto an extension of MediaType

### DIFF
--- a/lib/src/media_type_query.dart
+++ b/lib/src/media_type_query.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2021, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'package:http_parser/http_parser.dart';
+
+/// Convenience methods for querying a [MediaType]'s `type/subtype`.
+extension MediaTypeQuery on MediaType {
+  /// Determines if the [MediaType] is the same [type], and optional [subtype].
+  ///
+  /// If no [subtype] is specified only the [type] is checked. 
+  bool isMimeType(String type, [String subtype]) {
+    final subtypeMatch = subtype == null || subtype == this.subtype;
+    return type == this.type && subtypeMatch;
+  }
+}

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -16,6 +16,7 @@ import 'content_headers.dart';
 import 'context.dart';
 import 'headers.dart';
 import 'media_type_encoding.dart';
+import 'media_type_query.dart';
 
 /// Represents logic shared between [Request] and [Response].
 abstract class Message {
@@ -131,9 +132,11 @@ abstract class Message {
   /// and optional [subtype].
   bool isMimeType(String type, [String subtype]) {
     final mimeType = _contentType;
-    final subtypeMatch = subtype == null || subtype == mimeType.subtype;
+    if (mimeType == null) {
+      return false;
+    }
 
-    return type == mimeType.type && subtypeMatch;
+    return mimeType.isMimeType(type, subtype);
   }
 
   /// Returns the message body as byte chunks.

--- a/test/media_type_query_test.dart
+++ b/test/media_type_query_test.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2021, the HTTP Dart project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:http_parser/http_parser.dart';
+import 'package:http_next/src/media_type_query.dart';
+
+void main() {
+  group('isMimeType', () {
+    test('text', () {
+      final type = MediaType('text', 'plain');
+      expect(type.isMimeType('text'), isTrue);
+      expect(type.isMimeType('text', 'plain'), isTrue);
+      expect(type.isMimeType('text', 'csv'), isFalse);
+      expect(type.isMimeType('application'), isFalse);
+      expect(type.isMimeType('application', 'json'), isFalse);
+    });
+    test('application', () {
+      final type = MediaType('application', 'json');
+      expect(type.isMimeType('application'), isTrue);
+      expect(type.isMimeType('application', 'json'), isTrue);
+      expect(type.isMimeType('application', 'octet-stream'), isFalse);
+      expect(type.isMimeType('text'), isFalse);
+      expect(type.isMimeType('text', 'plain'), isFalse);
+    });
+  });
+}

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -266,6 +266,27 @@ void main() {
     });
   });
 
+  group('isMimeType', () {
+    test('is false without a content-type header', () {
+      final message = _createMessage();
+      expect(message.mimeType, isNull);
+      expect(message.isMimeType('application'), isFalse);
+      expect(message.isMimeType('text'), isFalse);
+      expect(message.isMimeType('application', 'octet-stream'), isFalse);
+      expect(message.isMimeType('text', 'plain'), isFalse);
+    });
+
+    test('can query based on type and subtype', () {
+      final message = _createMessage(headers: {'content-type': 'text/plain'});
+      expect(message.mimeType, isNotNull);
+      expect(message.isMimeType('application'), isFalse);
+      expect(message.isMimeType('text'), isTrue);
+      expect(message.isMimeType('application', 'octet-stream'), isFalse);
+      expect(message.isMimeType('text', 'plain'), isTrue);
+      expect(message.isMimeType('text', 'csv'), isFalse);
+    });
+  });
+
   group('encoding', () {
     group('is null and content-type header is unchanged with', () {
       group('no content-type header and', () {


### PR DESCRIPTION
Use an extension method on MediaType to determine whether its a specific MIME type. Modify Message to use the extension. Provide tests for the query.