### PR TITLE
feat: Add extension for default encoding of a MediaType

### DIFF
--- a/lib/src/media_type_encoding.dart
+++ b/lib/src/media_type_encoding.dart
@@ -7,6 +7,9 @@ import 'dart:convert';
 
 import 'package:http_parser/http_parser.dart';
 
+import 'media_type_query.dart';
+import 'mime_types.dart';
+
 /// Convenience methods around [MediaType] to interact with an [Encoding]
 /// specified by the `charset` parameter.
 extension MediaTypeEncoding on MediaType {
@@ -15,6 +18,22 @@ extension MediaTypeEncoding on MediaType {
   /// Retrieves the [Encoding] for the [MediaType] specified in the `charset`
   /// parameter.
   Encoding get encoding => Encoding.getByName(parameters[_charsetParameter]);
+
+  /// Retieves the default [Encoding] for the [MediaType].
+  ///
+  /// For `text` types the default encoding is [ascii]. For `application/json`
+  /// the default is [utf8]. For all other types no default is specified.
+  Encoding get defaultEncoding {
+    if (isMimeType(textType)) {
+      return ascii;
+    }
+
+    if (isMimeType(applicationType, jsonSubtype)) {
+      return utf8;
+    }
+
+    return null;
+  }
 
   /// Modifies the [Encoding] for the [MediaType] specified in the `charset`
   /// parameter.

--- a/test/media_type_encoding_test.dart
+++ b/test/media_type_encoding_test.dart
@@ -38,6 +38,24 @@ void main() {
       expect(mediaType.encoding, utf8);
     });
   });
+  group('defaultEncoding', () {
+    test('text', () {
+      final plain = _text();
+      expect(plain.defaultEncoding, ascii);
+      final csv = MediaType('text', 'csv');
+      expect(csv.defaultEncoding, ascii);
+    });
+    test('json', () {
+      final json = MediaType('application', 'json');
+      expect(json.defaultEncoding, utf8);
+    });
+    test('unknown', () {
+      final octet = MediaType('application', 'octet-stream');
+      expect(octet.defaultEncoding, isNull);
+      final image = MediaType('image', 'png');
+      expect(image.defaultEncoding, isNull);
+    });
+  });
   group('changeEncoding', () {
     test('ascii', () {
       final mediaType = _text().changeEncoding(ascii);


### PR DESCRIPTION
Add a method to MediaTypeEncoding which attempts to determine the default encoding for a MediaType. For `text` the default is ascii. For `application/json` its utf8.