### PR TITLE
refactor: Use dart:js_interop for browser client

### DIFF
--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -5,7 +5,7 @@
 // in the LICENSE file.
 
 import 'dart:async';
-import 'dart:html' as html;
+import 'dart:js_interop';
 import 'dart:typed_data';
 
 import 'package:async/async.dart';
@@ -36,59 +36,69 @@ class BrowserClient implements Client {
   /// The currently active XHRs.
   ///
   /// These are aborted if the client is closed.
-  final Set<html.HttpRequest> _xhrs = <html.HttpRequest>{};
+  final Set<_XmlHttpRequest> _xhrs = <_XmlHttpRequest>{};
 
   @override
   FutureOr<Response> send(Request request) async {
     final bytes = await collectBytes(request.read());
-    final xhr = html.HttpRequest();
+    final xhr = _XmlHttpRequest();
     _xhrs.add(xhr);
 
     xhr
-      ..open(request.method, request.url.toString())
+      ..open(request.method, request.url.toString(), true)
       ..responseType = 'arraybuffer'
       ..withCredentials = request.withCredentials;
-    request.headers.forEach(xhr.setRequestHeader);
+    for (final header in request.headers.entries) {
+      xhr.setRequestHeader(header.key, header.value);
+    }
 
     final completer = Completer<Response>();
-    unawaited(
-      xhr.onLoad.first.then((_) {
-        // ignore: avoid_as
-        final buffer = xhr.response as ByteBuffer;
-        completer.complete(
-          Response(
-            Uri.parse(xhr.responseUrl!),
-            xhr.status!,
-            reasonPhrase: xhr.statusText ?? '',
-            body: Stream.fromIterable([buffer.asUint8List()]),
-            headers: xhr.responseHeaders,
-          ),
-        );
-      }),
-    );
 
-    unawaited(
-      xhr.onError.first.then((_) {
-        // Unfortunately, the underlying XMLHttpRequest API doesn't expose any
-        // specific information about the error itself.
-        completer.completeError(
-          ClientException('XMLHttpRequest error', request.url),
-          StackTrace.current,
-        );
-      }),
-    );
+    void onLoad(JSAny _) {
+      final buffer = xhr.response as ByteBuffer;
+      completer.complete(
+        Response(
+          Uri.parse(xhr.responseURL),
+          xhr.status,
+          reasonPhrase: xhr.statusText,
+          body: Stream.fromIterable([buffer.asUint8List()]),
+          headers: xhr.responseHeaders,
+        ),
+      );
+    }
 
-    // Catch the abort event so futures complete when close is called.
-    unawaited(
-      xhr.onAbort.first.then((_) {
-        completer.completeError(
-          ClientException('Request cancelled', request.url),
-          StackTrace.current,
-        );
-      }),
-    );
+    xhr.addEventListener('load', onLoad.toJS);
 
-    xhr.send(bytes);
+    void onError(JSAny _) {
+      // Unfortunately, the underlying XMLHttpRequest API doesn't expose any
+      // specific information about the error itself.
+      completer.completeError(
+        ClientException('XMLHttpRequest error', request.url),
+        StackTrace.current,
+      );
+    }
+
+    xhr.addEventListener('error', onError.toJS);
+
+    void onAbort(JSAny _) {
+      completer.completeError(
+        ClientException('Request cancelled', request.url),
+        StackTrace.current,
+      );
+    }
+
+    xhr.addEventListener('abort', onAbort.toJS);
+
+    void onTimeout(JSAny _) {
+      completer.completeError(
+        ClientException('Request timed out', request.url),
+        StackTrace.current,
+      );
+    }
+
+    xhr.addEventListener('timeout', onTimeout.toJS);
+
+    xhr.send(bytes.toJS);
 
     try {
       return await completer.future;
@@ -102,5 +112,61 @@ class BrowserClient implements Client {
     for (final xhr in _xhrs) {
       xhr.abort();
     }
+  }
+}
+
+@JS('XMLHttpRequest')
+extension type _XmlHttpRequest._(JSObject _) {
+  external factory _XmlHttpRequest();
+
+  external void open(
+    String method,
+    String url, [
+    bool async,
+    String? username,
+    String? password,
+  ]);
+  external void setRequestHeader(String name, String value);
+  external void send([JSAny? body]);
+  external void abort();
+  external String getAllResponseHeaders();
+
+  external JSAny? get response;
+  external String get responseURL;
+  external int get status;
+  external String get statusText;
+
+  external String get responseType;
+  external set responseType(String value);
+
+  external bool get withCredentials;
+  external set withCredentials(bool value);
+
+  external void addEventListener(
+    String type,
+    JSFunction? callback, [
+    JSAny options,
+  ]);
+
+  Map<String, String> get responseHeaders {
+    // from Closure's goog.net.Xhrio.getResponseHeaders.
+    final headers = <String, String>{};
+    for (var header in getAllResponseHeaders().split('\r\n')) {
+      if (header.isEmpty) {
+        continue;
+      }
+
+      final splitAt = header.indexOf(': ');
+      if (splitAt == -1) {
+        continue;
+      }
+
+      final key = header.substring(0, splitAt).toLowerCase();
+      final value = header.substring(splitAt + 2);
+      headers[key] =
+          headers.containsKey(key) ? '${headers[key]}, $value' : value;
+    }
+
+    return headers;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: HTTP request middleware for Dart
 homepage: https://github.com/http-dart/http-next
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   async: ^2.5.0


### PR DESCRIPTION
Create an extension type for `XMLHttpRequest` and use that instead of `HttpRequest` from `dart:html`. The `web` package is not used because it does not expose all of the methods that were being used in the original client. Also simplify things to not use a `Stream` and use `addEventListener` directly.